### PR TITLE
Add dark mode syntax highlighting

### DIFF
--- a/themes/default/assets/css/style.css
+++ b/themes/default/assets/css/style.css
@@ -21,6 +21,18 @@
   --input-bg-color: white;
   --input-border-color: color-mix(in srgb, var(--input-bg-color), black 10%);
   --code-font-family: SFMono-Regular, Menlo, Consolas, Monaco, "Liberation Mono", "Lucida Console", monospace;
+
+  --code-s: #448800; /* string */
+  --code-i: #1c9963; /* interpolation */
+  --code-x: #872bff; /* constant */
+  --code-m: #d30038; /* method */
+  --code-f: #d30038; /* function */
+  --code-k: #0069c2; /* keyword */
+  --code-c: #858585; /* comment */
+  --code-o: #858585; /* operator */
+  --code-n: #007936; /* number */
+  --code-p: #c4c4c4; /* prompt */
+  --code-e: #ff7989; /* error */
 }
 
 html {
@@ -447,48 +459,48 @@ footer {
 }
 
 [class^=language-] .s {
-  color: #007936;
+  color: var(--code-s);
 }
 
 [class^=language-] .i {
-  color: #690;
+  color: var(--code-i);
 }
 
 [class^=language-] .x {
-  color: #872bff;
+  color: var(--code-x);
 }
 
 [class^=language-] .m {
-  color: #d30038;
+  color: var(--code-m);
   font-style: italic;
 }
 
 [class^=language-] .f {
-  color: #d30038;
+  color: var(--code-f);
 }
 
 [class^=language-] .k {
-  color: #0069c2;
+  color: var(--code-k);
 }
 
 [class^=language-] .c {
-  color: #858585;
+  color: var(--code-c);
 }
 
 [class^=language-] .o {
-  color: #858585;
+  color: var(--code-o);
 }
 
 [class^=language-] .n {
-  color: #007936;
+  color: var(--code-n);
 }
 
 [class^=language-] .p {
-  color: #c4c4c4;
+  color: var(--code-p);
 }
 
 [class^=language-] .e {
-  color: #ff7989;
+  color: var(--code-e);
 }
 
 /** highlight package ends */
@@ -646,9 +658,17 @@ pre.off [class*=-repl] .e, pre.off [class*=-repl] .r, pre.off [class*=-repl] .p 
     --sidebar-color: #1b1c1e;
     --input-bg-color: #303134;
     --input-border-color: #303134;
-  }
 
-  [class^=language-] .s {
-    color: #2dcb74;
+    --code-s: #88bb44; /* string */
+    --code-i: #3ebb85; /* interpolation */
+    --code-x: #cd6fff; /* constant */
+    --code-m: #f5558c; /* method */
+    --code-f: #f5558c; /* function */
+    --code-k: #559cf6; /* keyword */
+    --code-c: #858585; /* comment */
+    --code-o: #a8a8a8; /* operator */
+    --code-n: #88beac; /* number */
+    --code-p: #c4c4c4; /* prompt */
+    --code-e: #ff7989; /* error */
   }
 }


### PR DESCRIPTION
This PR modifies some of the syntax highlighting, mainly adding dark-mode syntax highlighting, which could be very hard to read before. Strings have also been modified in light mode, to be darker.

**Before:**
![Screenshot From 2025-06-01 22-08-00](https://github.com/user-attachments/assets/383ec21f-d7cf-4479-aa36-690b032e7b45)
![Screenshot From 2025-06-01 22-08-06](https://github.com/user-attachments/assets/dc35d608-f220-45d1-9f86-e8f687711de7)

**After:**
![Screenshot From 2025-06-01 22-13-03](https://github.com/user-attachments/assets/c8603da6-6a33-4a16-8d5b-a589d78c5a78)
![Screenshot From 2025-06-01 22-23-47](https://github.com/user-attachments/assets/5ac798c3-21b6-48a1-94ce-01d6befc868a)
